### PR TITLE
Test and support all control flow structures

### DIFF
--- a/sqwhiff/sqf/binary_keywords.hpp
+++ b/sqwhiff/sqf/binary_keywords.hpp
@@ -8,6 +8,7 @@
 namespace SQF {
 
 const std::unordered_multimap<std::string, BinaryCommand> Binary_Keywords{
+    {":", BinaryCommand(Type::switch_type, Type::code, Type::any)},
     {"!=", BinaryCommand(Type::scalar, Type::scalar, Type::boolean)},
     {"!=", BinaryCommand(Type::boolean, Type::boolean, Type::boolean)},
     {"!=", BinaryCommand(Type::string, Type::string, Type::boolean)},

--- a/sqwhiff/tokens/token_maps.hpp
+++ b/sqwhiff/tokens/token_maps.hpp
@@ -10,7 +10,7 @@ const std::unordered_map<char, TokenType> SQF_Token_Chars{
     {'^', TokenType::pow},    {'%', TokenType::mod},    {'#', TokenType::hash},
     {'(', TokenType::lparen}, {')', TokenType::rparen}, {'[', TokenType::lsqb},
     {']', TokenType::rsqb},   {'{', TokenType::lcurl},  {'}', TokenType::rcurl},
-};
+    {':', TokenType::keyword}};
 
 const std::unordered_map<std::string, TokenType> SQF_Token_Keywords{
     {"private", TokenType::private_op},

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -106,6 +106,13 @@ cc_test(
 
 # Parser tests
 cc_test(
+  name = "parser-control-flow",
+  size = "small",
+  srcs = ["parser/control_flow_test.cpp"],
+  deps = [":parser-test"],
+)
+
+cc_test(
   name = "parser-errors",
   size = "small",
   srcs = ["parser/errors_test.cpp"],

--- a/tests/parser/control_flow_test.cpp
+++ b/tests/parser/control_flow_test.cpp
@@ -43,3 +43,10 @@ TEST_F(ParserTest, HandlesForEachLoop) {
   EXPECT_EQ("({<NoOp>} foreach [<Dec:1>,<Dec:2>,<Dec:3>,<Dec:4>])",
             parse("{} foreach [1,2,3,4]"));
 }
+
+TEST_F(ParserTest, HandlesSwitchStructure) {
+  EXPECT_EQ(
+      "((switch <Dec:1>) do {(case <Dec:1>),((case <Dec:2>) : {<NoOp>}),(case "
+      "<Dec:3>),(default {<NoOp>}),<NoOp>})",
+      parse("switch (1) do { case 1; case 2: {}; case 3; default {}; }"));
+}

--- a/tests/parser/control_flow_test.cpp
+++ b/tests/parser/control_flow_test.cpp
@@ -1,0 +1,45 @@
+#include "tests/parser/_test.hpp"
+
+TEST_F(ParserTest, HandlesIfStructure) {
+  EXPECT_EQ("((if <Var:condition>) then {(true)})",
+            parse("if (condition) then {true}"));
+}
+
+TEST_F(ParserTest, HandlesIfElseStructure) {
+  EXPECT_EQ("((if <Var:condition>) then ({(true)} else {(false)}))",
+            parse("if (condition) then {true} else {false}"));
+}
+
+TEST_F(ParserTest, HandlesIfArrayStructure) {
+  EXPECT_EQ("((if <Var:condition>) then [{(true)},{(false)}])",
+            parse("if (condition) then [{true},{false}]"));
+}
+
+TEST_F(ParserTest, HandlesWhileLoop) {
+  EXPECT_EQ("((while {<Var:condition>}) do {<NoOp>})",
+            parse("while {condition} do {}"));
+}
+
+TEST_F(ParserTest, HandlesForLoop) {
+  EXPECT_EQ(
+      "((for [{<Var:_i> = (<Dec:0>)},{(<Var:_i> < <Dec:10>)},{<Var:_i> = "
+      "((<Var:_i> + <Dec:1>))}]) do {<NoOp>})",
+      parse("for [{_i = 0}, {_i < 10}, {_i = _i+1}] do {}"));
+}
+
+TEST_F(ParserTest, HandlesForFromToLoop) {
+  EXPECT_EQ("((((for <Str:_i>) from <Dec:0>) to <Dec:10>) do {<NoOp>})",
+            parse("for \"_i\" from 0 to 10 do {}"));
+}
+
+TEST_F(ParserTest, HandlesForFromToStepLoop) {
+  EXPECT_EQ(
+      "(((((for <Str:_i>) from <Dec:0>) to <Dec:10>) step <Dec:2>) do "
+      "{<NoOp>})",
+      parse("for \"_i\" from 0 to 10 step 2 do {}"));
+}
+
+TEST_F(ParserTest, HandlesForEachLoop) {
+  EXPECT_EQ("({<NoOp>} foreach [<Dec:1>,<Dec:2>,<Dec:3>,<Dec:4>])",
+            parse("{} foreach [1,2,3,4]"));
+}

--- a/update-lang.py
+++ b/update-lang.py
@@ -89,6 +89,9 @@ def get_types(type: str) -> List[str]:
     finally:
         return types
 
+# Inject special non-command for parsing use
+binary_commands.append(binary(":", "any", "switch_type", "code"))
+
 # By evaluating the SQF array output as a Python literal a list is easily produced
 with open("supportInfo.out", "r") as file:
     supportInfo = ast.literal_eval(


### PR DESCRIPTION
Adds tests for parsing all control flow structures in SQF.

Fixes parsing of `switch` structure by considering `:` to be a binary operating keyword.

closes #34