### PR TITLE
test(pp): use mocking for unit testing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,7 +68,8 @@
     "numbers": "cpp",
     "semaphore": "cpp",
     "stop_token": "cpp",
-    "thread": "cpp"
+    "thread": "cpp",
+    "*.tpp": "cpp"
   },
   "editor.defaultFormatter": "ms-vscode.cpptools",
   "editor.formatOnSave": true

--- a/sqwhiff/BUILD
+++ b/sqwhiff/BUILD
@@ -14,7 +14,7 @@ cc_library(
 
 cc_library(
     name = "preprocessor",
-    hdrs = glob(["preprocessor/*.hpp"]),
+    hdrs = glob(["preprocessor/*.hpp", "preprocessor/*.tpp"]),
     srcs = glob(["preprocessor/*.cpp"],  ["preprocessor/*.test.cpp"]),
     deps = [":structures", ":errors"],
     visibility = ["//tests:__pkg__"],

--- a/sqwhiff/preprocessor/macro_manager.hpp
+++ b/sqwhiff/preprocessor/macro_manager.hpp
@@ -4,7 +4,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "sqwhiff/preprocessor/source_consumer.hpp"
 #include "sqwhiff/structures/macro_definition.hpp"
 
 namespace sqwhiff {
@@ -16,13 +15,14 @@ using macro_storage = std::unordered_map<std::string, MacroDefinition>;
 using shared_macro_storage = std::shared_ptr<macro_storage>;
 
 // A class for the sole purpose of managing and expanding macros recursively
+template <class Consumer>
 class MacroManager {
   // Holds the current set of macro definitions
   shared_macro_storage defined_;
 
   // Helpers for recursively processing sections of source
-  SourceString getWord(SourceConsumer&);
-  std::vector<SourceString> getArguments(SourceConsumer&);
+  SourceString getWord(Consumer&);
+  std::vector<SourceString> getArguments(Consumer&);
 
   // Helpers for recursively processing sections of extracted source
   SourceString getWord(std::vector<SourceChar>::const_iterator&,
@@ -57,7 +57,9 @@ class MacroManager {
   void define(const SourceString&);
 
   // Reads the next word from source and expands it if a macro is found
-  SourceString processWord(SourceConsumer&);
+  SourceString processWord(Consumer&);
 };
 
 }  // namespace sqwhiff
+
+#include "sqwhiff/preprocessor/macro_manager.tpp"

--- a/sqwhiff/preprocessor/macro_manager.test.cpp
+++ b/sqwhiff/preprocessor/macro_manager.test.cpp
@@ -1,21 +1,37 @@
 #include "sqwhiff/preprocessor/macro_manager.hpp"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <sstream>
 
 using sqwhiff::MacroManager;
 using sqwhiff::SourceChar;
-using sqwhiff::SourceConsumer;
 using sqwhiff::SourceString;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+class MockSourceConsumer {
+ public:
+  MOCK_METHOD(SourceChar, advance, (), ());
+  MOCK_METHOD(SourceChar, peek, (), ());
+  MOCK_METHOD(SourceChar, at, (), ());
+};
 
 TEST(MacroManager, OutputsNormalWord) {
-  // TODO: Somehow mock the output of consumer for unit testing
-  std::stringstream source("allUnits");
-  SourceConsumer consumer(source);
-  consumer.advance();
+  NiceMock<MockSourceConsumer> consumer;
 
-  MacroManager manager;
+  EXPECT_CALL(consumer, at()).Times(1).WillOnce(Return(SourceChar('a')));
+  EXPECT_CALL(consumer, advance())
+      .Times(8)
+      .WillOnce(Return(SourceChar('l')))
+      .WillOnce(Return(SourceChar('l')))
+      .WillOnce(Return(SourceChar('U')))
+      .WillOnce(Return(SourceChar('n')))
+      .WillOnce(Return(SourceChar('i')))
+      .WillOnce(Return(SourceChar('t')))
+      .WillOnce(Return(SourceChar('s')))
+      .WillOnce(Return(SourceChar('\0')));
+
+  MacroManager<MockSourceConsumer> manager;
 
   SourceString output = manager.processWord(consumer);
 

--- a/sqwhiff/preprocessor/macro_manager.tpp
+++ b/sqwhiff/preprocessor/macro_manager.tpp
@@ -1,4 +1,4 @@
-#include "sqwhiff/preprocessor/macro_manager.hpp"
+#pragma once
 
 #include <algorithm>
 
@@ -8,21 +8,28 @@
 
 namespace sqwhiff {
 
-MacroManager::MacroManager() { defined_ = std::make_shared<macro_storage>(); }
+template <class Consumer>
+MacroManager<Consumer>::MacroManager() {
+  defined_ = std::make_shared<macro_storage>();
+}
 
-bool MacroManager::isMacro(const std::string& id) {
+template <class Consumer>
+bool MacroManager<Consumer>::isMacro(const std::string& id) {
   return defined_->find(id) != defined_->end();
 }
 
-MacroDefinition MacroManager::getDefinition(const std::string& id) {
+template <class Consumer>
+MacroDefinition MacroManager<Consumer>::getDefinition(const std::string& id) {
   return defined_->at(id);
 }
 
-bool MacroManager::undefine(const std::string& id) {
+template <class Consumer>
+bool MacroManager<Consumer>::undefine(const std::string& id) {
   return defined_->erase(id) > 0;
 }
 
-void MacroManager::define(const SourceString& definition) {
+template <class Consumer>
+void MacroManager<Consumer>::define(const SourceString& definition) {
   // Will consume the definition procedurally
   auto at = definition.chars.begin();
   auto limit = definition.chars.end();
@@ -192,7 +199,8 @@ void MacroManager::define(const SourceString& definition) {
   (*defined_)[id] = std::move(result);
 }
 
-std::vector<SourceString> MacroManager::parameter_replacement(
+template <class Consumer>
+std::vector<SourceString> MacroManager<Consumer>::parameter_replacement(
     const MacroDefinition& macro, const std::vector<SourceString>& arguments) {
   std::vector<SourceString> result;
 
@@ -225,7 +233,8 @@ std::vector<SourceString> MacroManager::parameter_replacement(
   return result;
 };
 
-SourceString MacroManager::expand(
+template <class Consumer>
+SourceString MacroManager<Consumer>::expand(
     const MacroDefinition& macro, const std::vector<SourceString>& arguments,
     const std::unordered_set<std::string>& ignores) {
   SourceString expanded;
@@ -252,7 +261,8 @@ SourceString MacroManager::expand(
   return expanded;
 }
 
-SourceString MacroManager::processWord(SourceConsumer& source) {
+template <class Consumer>
+SourceString MacroManager<Consumer>::processWord(Consumer& source) {
   SourceString word = getWord(source);
 
   if (isMacro(word)) {
@@ -264,7 +274,8 @@ SourceString MacroManager::processWord(SourceConsumer& source) {
   return word;
 }
 
-SourceString MacroManager::processWord(
+template <class Consumer>
+SourceString MacroManager<Consumer>::processWord(
     std::vector<SourceChar>::const_iterator& at,
     const std::vector<SourceChar>::const_iterator& end,
     const std::unordered_set<std::string>& ignores) {
@@ -280,19 +291,21 @@ SourceString MacroManager::processWord(
   return word;
 }
 
-SourceString MacroManager::getWord(SourceConsumer& source) {
+template <class Consumer>
+SourceString MacroManager<Consumer>::getWord(Consumer& source) {
   SourceString word;
 
   // Assume caller checked that the initial wasn't a digit
-  while (std::isalnum(source.at()) || source.at() == '_') {
-    word.chars.push_back(source.at());
-    source.advance();
+  for (SourceChar at = source.at(); std::isalnum(at) || at == '_';
+       at = source.advance()) {
+    word.chars.push_back(at);
   }
 
   return word;
 }
 
-SourceString MacroManager::getWord(
+template <class Consumer>
+SourceString MacroManager<Consumer>::getWord(
     std::vector<SourceChar>::const_iterator& at,
     const std::vector<SourceChar>::const_iterator& end) {
   SourceString word;
@@ -306,7 +319,9 @@ SourceString MacroManager::getWord(
   return word;
 }
 
-std::vector<SourceString> MacroManager::getArguments(SourceConsumer& source) {
+template <class Consumer>
+std::vector<SourceString> MacroManager<Consumer>::getArguments(
+    Consumer& source) {
   std::vector<SourceString> arguments = {};
 
   SourceChar start = source.at();
@@ -360,7 +375,8 @@ std::vector<SourceString> MacroManager::getArguments(SourceConsumer& source) {
   return arguments;
 }
 
-std::vector<SourceString> MacroManager::getArguments(
+template <class Consumer>
+std::vector<SourceString> MacroManager<Consumer>::getArguments(
     std::vector<SourceChar>::const_iterator& at,
     const std::vector<SourceChar>::const_iterator& end,
     const std::unordered_set<std::string>& ignores) {

--- a/sqwhiff/preprocessor/preprocessor.cpp
+++ b/sqwhiff/preprocessor/preprocessor.cpp
@@ -11,7 +11,7 @@ using sqwhiff::PreprocessingError;
 
 Preprocessor::Preprocessor(
     std::istream& to_read, fs::path open_file, fs::path internal_dir,
-    std::shared_ptr<MacroManager> macro_context,
+    std::shared_ptr<MacroManager<SourceConsumer>> macro_context,
     const std::unordered_set<std::string>* include_context)
     : source_(to_read, open_file) {
   // Move to first character straight away
@@ -33,7 +33,7 @@ Preprocessor::Preprocessor(
   }
 
   if (macro_context == nullptr) {
-    macro_context_ = std::make_shared<MacroManager>();
+    macro_context_ = std::make_shared<MacroManager<SourceConsumer>>();
   } else {
     macro_context_ = macro_context;
   }

--- a/sqwhiff/preprocessor/preprocessor.hpp
+++ b/sqwhiff/preprocessor/preprocessor.hpp
@@ -45,7 +45,7 @@ class Preprocessor {
   void skipComment();
 
   // Macro definitions which are shared across inclusion boundaries
-  std::shared_ptr<MacroManager> macro_context_;
+  std::shared_ptr<MacroManager<SourceConsumer>> macro_context_;
 
   // Included files to error on and prevent recursion
   std::unordered_set<std::string> inclusion_context_;
@@ -65,7 +65,7 @@ class Preprocessor {
   // Constructor enables recursive reuse of the class. Used for:
   //   - Nested file inclusion (with shared macro modification)
   Preprocessor(std::istream&, fs::path = "", fs::path = "",
-               std::shared_ptr<MacroManager> = nullptr,
+               std::shared_ptr<MacroManager<SourceConsumer>> = nullptr,
                // Set of paths not to include (prevent recursion)
                const std::unordered_set<std::string>* = nullptr);
   SourceChar get();

--- a/sqwhiff/structures/source_char.hpp
+++ b/sqwhiff/structures/source_char.hpp
@@ -16,6 +16,8 @@ struct SourceChar {
   operator char() const;
   bool operator==(char) const;
   void operator=(char);
+
+  SourceChar(char c = '\0') : character(c){};
 };
 
 }  // namespace sqwhiff


### PR DESCRIPTION
- Implemented mocking of the SourceConsumer so that the MacroManager can
  be unit tested independently.
- Made the MacroManager a class template to enable compile-time
  polymorphism so that I can plug in the mocked consumer in testing.
- Added a simple constructor to the SourceChar struct to quickly return
  values from the mocked object.
- Optimised the MacroManager's getWord function to remove unnecessary
  extra calls to the consumer object.