### PR TITLE
fix: improve path handling for safety

### DIFF
--- a/sqwhiff/main.cpp
+++ b/sqwhiff/main.cpp
@@ -25,7 +25,7 @@ static void show_usage() {
 }
 
 static int analyzeFile(fs::path file_path, std::string internal_root) {
-  file_path = fs::absolute(file_path);
+  file_path = fs::weakly_canonical(file_path);
   std::ifstream file_in(file_path);
 
   if (file_in.is_open()) {


### PR DESCRIPTION
Dirtectory iteration was running into issues with seemingly mashed
together relative paths. Using canonical paths ensures the same
file/directory is always resolved the same. Avoiding changes to the
current working directory is just sensible and avoids unexpected
behaviour caused by doing so.